### PR TITLE
Hotfix/hex string

### DIFF
--- a/Sources/SafariWalletCore/Extensions/String.swift
+++ b/Sources/SafariWalletCore/Extensions/String.swift
@@ -22,11 +22,8 @@ extension String {
     public func addHexPrefix() -> String {
         return hexPrefix.appending(self)
     }
-    
-    public func toHexString() -> String {
-        guard let data = data(using: .utf8) else {
-            return ""
-        }
-        return data.toHexString()
+        
+    public func toHexString(uppercase: Bool = false, prefix: String? = nil) -> String {
+        return unicodeScalars.map { prefix ?? "" + .init($0.value, radix: 16, uppercase: uppercase) }.joined()
     }
 }

--- a/Sources/SafariWalletCore/Models/Wei.swift
+++ b/Sources/SafariWalletCore/Models/Wei.swift
@@ -20,7 +20,7 @@ public struct Wei {
     private (set) var value: BigInt
     
     public var hexString: String {
-        value.description.toHexString().addHexPrefix()
+        return String(value, radix: 16).addHexPrefix()
     }
 
     // MARK: - Conversions


### PR DESCRIPTION
`Wei.hexString()` mistakenly used utf-8 encoded values instead of decimals, resulting in decimal 0 WEI being converted to 0x30 WEI. hexString now uses `String(value, radix: 16).addHexPrefix()` to return the correct value.
